### PR TITLE
updated token generation method

### DIFF
--- a/application/hooks/csrf.php
+++ b/application/hooks/csrf.php
@@ -55,7 +55,7 @@ class CSRF_Protection
     if ($this->CI->session->userdata(self::$token_name) === FALSE)
     {
       // Generate a token and store it on session, since old one appears to have expired.
-      self::$token = md5(uniqid() . microtime() . rand());
+      self::$token = bin2hex(openssl_random_pseudo_bytes(16));
 
       $this->CI->session->set_userdata(self::$token_name, self::$token);
     }


### PR DESCRIPTION
The token generation method isn't cryptographically secure.

http://stackoverflow.com/questions/2593807/md5uniqid-makes-sense-for-random-unique-tokens

updated to use openssl_random_pseudo_bytes instead
